### PR TITLE
Adjusting buffer size on strcpy

### DIFF
--- a/src/parse/response/parse_response.c
+++ b/src/parse/response/parse_response.c
@@ -29,7 +29,7 @@ static int get_response_code(char *line) {
   if (!ret) {
     char code_str[4] = {0};
     // Extract the matched response code substring
-    strncpy(code_str, line + pmatch[0].rm_so, 4);
+    strncpy(code_str, line + pmatch[0].rm_so, 3);
     regfree(&regex);
     code_str[3] = '\0';
     // Convert the response code string to an integer
@@ -186,6 +186,6 @@ HTTPResponse *parse_response(char *response) {
     return NULL;
   }
   // Copy the remaining content as the response body
-  strncpy(http_response->body, buffer, buffer_size);
+  strncpy(http_response->body, buffer, buffer_size-1);
   return http_response;
 }

--- a/test.sh
+++ b/test.sh
@@ -37,7 +37,7 @@ done
 # your main program, use other compiler flags etc.
 
 # Compile the test
-gcc -o tests $all_files -O0 -g -Wall -Wextra -Werror -Wno-unused-parameter \
+gcc -o tests $all_files -O3 -g -Wall -Wextra -Werror -Wno-unused-parameter \
  -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function \
  -Wno-unused-but-set-variable -Wno-unused-but-set-parameter -Wno-unused-result \
  -Wno-unused-label -Wno-unused-val


### PR DESCRIPTION
Adjusting buffer size on strcpy in order to always have a free bit to alocate the NULL character 0.